### PR TITLE
Fix #170

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -657,7 +657,7 @@ export async function runPreConfigureScript(progress: vscode.Progress<{}>, scrip
     } else {
         runCommand = "/bin/bash";
         scriptArgs.push("-c");
-        scriptArgs.push(`"source '${wrapScriptFile}"'`);
+        scriptArgs.push(`"source '${wrapScriptFile}'"`);
     }
 
     try {


### PR DESCRIPTION
Wrongfully-positioned single quote broke the pre-configure script on Linux.
Put the single quote back where it should be.

Fixes #170